### PR TITLE
Fix gemspec when gem is checked out from a custom branch

### DIFF
--- a/lib/ruby-prof/printers/flame_graph_printer.rb
+++ b/lib/ruby-prof/printers/flame_graph_printer.rb
@@ -7,8 +7,6 @@ module RubyProf
   #
   class FlameGraphPrinter < AbstractPrinter
 
-    VERSION = '0.3.0'
-
     def print(output = STDOUT, options = {})
       @output = output
       setup_options(options)

--- a/ruby-prof-flamegraph.gemspec
+++ b/ruby-prof-flamegraph.gemspec
@@ -1,11 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'ruby-prof-flamegraph'
-
 Gem::Specification.new do |spec|
   spec.name          = "ruby-prof-flamegraph"
-  spec.version       = RubyProf::FlameGraphPrinter::VERSION
+  spec.version       = '0.3.0'
   spec.authors       = ["Thai Pangsakulyanont"]
   spec.email         = ["org.yi.dttvb@gmail.com"]
   spec.summary       = %q{ruby-prof printer that exports to fold stacks compatible with FlameGraph}
@@ -16,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", [">= 1.7", "< 3.0"]
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "ruby-prof", ">= 0.13", "< 2"
 end


### PR DESCRIPTION
### What?
The error message is the following:
```
[!] There was an error while loading `ruby-prof-flamegraph.gemspec`: cannot load such file -- ruby-prof
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

 #  from /Users/alexey/projects/ruby-prof-flamegraph-bug/vendor/bundle/ruby/2.6.0/bundler/gems/ruby-prof-flamegraph-bc3a78f41e78/ruby-prof-flamegraph.gemspec:4
 #  -------------------------------------------
 #  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 >  require 'ruby-prof-flamegraph'
 #
 #  -------------------------------------------
```
 It seems to happen because `ruby-prof` is missing from the `$LOAD_PATH` during gem initialization.

 ### How to reproduce
 Create the following `Gemfile` inside an empty folder:
 ```
 # frozen_string_literal: true
 source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem 'ruby-prof-flamegraph', git: 'https://github.com/oozou/ruby-prof-flamegraph', branch: 'master'
 ```
 And run `bundle install --path=vendor/bundle`
 It's important to run `bundle install` with custom path to make installation go from scratch and
 not use any already installed gems.
 
 ### What was done  
 I thought the simplest way to avoid this situation is just to hardcode the gem version inside the `.gemspec` file and get rid of loading the gem by itself. I've also widened bundler requirements to allow usage of Bundler 2.0.