### PR TITLE
Change ruby-prof version

### DIFF
--- a/ruby-prof-flamegraph.gemspec
+++ b/ruby-prof-flamegraph.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", [">= 1.7", "< 3.0"]
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_runtime_dependency "ruby-prof", ">= 0.13", "< 2"
+  spec.add_runtime_dependency "ruby-prof", ">= 1.4.2"
 end


### PR DESCRIPTION
To support the code changes in my last PR, the `ruby-prof` version should be >= 1.4.2.
Fixing the ruby-prof version in this PR.